### PR TITLE
feat: add typescript declaration for tsconfig usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "author": "Shigma <shigma10826@gmail.com>",
   "license": "MIT",
   "files": [
-    "lib"
+    "lib",
+    "types.d.ts"
   ],
   "scripts": {
     "build": "tsc -b"

--- a/readme.md
+++ b/readme.md
@@ -19,3 +19,20 @@ node -r yml-register path/to/index.js
 require('yml-register')
 require('/path/to/my-file.yaml') // now it works!
 ```
+
+### Type Fixing for TypeScript Users
+
+In order to fixing the error `Cannot find module 'file.yaml' or its corresponding type declarations.` when using `import` statement in TypeScript,
+we provides a type declaration bundled in this package.
+
+What you need is to append `compilerOptions.types` by `yml-register/types` in `tsconfig.json`.
+
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "yml-register/types"
+    ]
+  }
+}
+```

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,9 @@
+declare module '*.yaml' {
+  const content: any
+  export default content
+}
+
+declare module '*.yml' {
+  const content: any
+  export default content
+}


### PR DESCRIPTION
Add a type declaration file to fixing the error `Cannot find module 'file.yaml' or its corresponding type declarations.`